### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CM4_LiteRTOS.yml
+++ b/.github/workflows/CM4_LiteRTOS.yml
@@ -6,6 +6,8 @@
 # -----------------------------------------------------
 
 name: CM4_LiteRTOS
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/imahjoub/CM4_LiteRTOS/security/code-scanning/1](https://github.com/imahjoub/CM4_LiteRTOS/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the minimum required permissions for the job(s). Since the job only checks out code, installs packages, and runs build commands, it does not need write access to repository contents, issues, or pull requests. The minimal required permission is `contents: read`. This block should be added at the root level of the workflow (above `jobs:`) to apply to all jobs, unless specific jobs require different permissions. No additional imports or definitions are needed; just a YAML block addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
